### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -3,6 +3,9 @@ name: Build/Release Stable
 on:
   release:
     types: [ published ]
+permissions:
+  contents: read
+  packages: write
 env:
   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
   ACTIONS_ALLOW_UNSECURE_COMMANDS: true


### PR DESCRIPTION
Potential fix for [https://github.com/shrunbr/cloudflare-ddns/security/code-scanning/3](https://github.com/shrunbr/cloudflare-ddns/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the workflow's actions, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to GitHub Container Registry (GHCR).

The `permissions` block should be added at the root level of the workflow to apply to all jobs, as there is only one job (`build-release-stable`) in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
